### PR TITLE
Add support for DDEV

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The plugin also supports configuration via composer.json `extra` section.
             "docker-image-name": "auto",
             "docker-tag": "auto",
             "docker-base": {
+                "base-flavor": "bitnami",
                 "image": "bitnami/mariadb:10.4",
                 "user": "drupal8",
                 "password": "drupal8",
@@ -117,6 +118,28 @@ You can use the `docker-base` configuration to specify the base image to use to 
 
 The base image details cannot be customized from the command line. They must be specified via the `composer.json`'s extra section.
 
+### DDEV base image
+
+The defaults for `docker-base` depend on the value of `base-flavor` setting. By default, the `base-flavor` is set to `bitnami` and the defaults are set as above. However, if `base-flavor` is `ddev`, the defaults change to the following:
+
+```json
+{
+    "extra": {
+        "dbdocker": {
+            "docker-base": {
+                "base-flavor": "ddev",
+                "image": "drud/ddev-dbserver-mariadb-10.4:v1.17.0",
+                "user": "db",
+                "password": "db",
+                "database": "db"
+            }
+        }
+    }
+}
+```
+
+These are the defaults required for building database images compatible for DDEV.
+
 ## Default options
 
 The plugin tries to guess most values for input to correctly select the source, build the image, and push it.
@@ -135,13 +158,15 @@ The image tag, unless specified with the `--docker-tag` option, is assumed to be
 
 ### Determining the database source
 
-Three database sources are supported: `file`, `lando`, and `drush`. The source can be explicitly specified using the `--db-source` option. If not specified, the following rules are used to determine the source.
+These database sources are supported: `file`, `lando`, `ddev`, and `drush`. The source can be explicitly specified using the `--db-source` option. If not specified, the following rules are used to determine the source.
 * If the `--db-file` option is present, then the source is set as `file`.
 * If a file called `.lando.yml` is present, then the source is set as `lando`.
-  * As an exception to above, the plugin attempts to detect if it is running inside a lando container. If so, the source is set to `drush`.
-* If the above two conditions fail, then the source is assumed to be `drush`.
+    * As an exception to above, the plugin attempts to detect if it is running inside a lando container. If so, the source is set to `drush`.
+* If a directory called `.ddev` is present, then the source is set as `ddev`.
+    * As an exception to above, the plugin attempts to detect if it is running inside a DDEV container. If so, the source is set to `drush`.
+* If the above conditions fail, then the source is assumed to be `drush`.
 
-In case the source is `lando` or `drush`, the `drush sql:dump` command is used to obtain the SQL file. If the source is `lando`, then the drush command is executed inside of the Lando container like so: `lando drush ...`.
+In case the source is `lando`, `ddev`, or `drush`, the `drush sql:dump` command is used to obtain the SQL file. If the source is `lando` or `ddev`, then the drush command is executed inside the relevant container like so: `lando drush ...` or `ddev drush ...`.
 
 ## Reporting problems
 

--- a/assets/dockerize-db-ddev/Dockerfile
+++ b/assets/dockerize-db-ddev/Dockerfile
@@ -1,0 +1,25 @@
+# This image is used to copy and install the databases.
+ARG BASE_IMAGE=drud/ddev-dbserver-mariadb-10.4:v1.17.0
+FROM ${BASE_IMAGE} AS build
+ARG BASE_IMAGE_USER
+ARG BASE_IMAGE_PASSWORD
+ARG BASE_IMAGE_DATABASE
+
+ENV ALLOW_EMPTY_PASSWORD=yes
+ENV MARIADB_USER=${BASE_IMAGE_USER:-db}
+ENV MARIADB_PASSWORD=${BASE_IMAGE_PASSWORD:-db}
+ENV MARIADB_DATABASE=${BASE_IMAGE_DATABASE:-db}
+
+COPY create_init_db.sh /
+
+COPY dumps/ /docker-entrypoint-initdb.d/
+COPY zzzz-truncate-caches.sql /docker-entrypoint-initdb.d/
+
+RUN /create_init_db.sh
+RUN rm -rf /var/lib/mysql/*
+RUN chmod -R ugo+rw /mysqlbase && find /mysqlbase -type d | xargs chmod ugo+rwx
+
+# This image is used to copy the installed databases and configure MySQL.
+FROM ${BASE_IMAGE}
+
+COPY --from=build /mysqlbase /mysqlbase

--- a/assets/dockerize-db-ddev/README.md
+++ b/assets/dockerize-db-ddev/README.md
@@ -1,0 +1,3 @@
+# Dockerize your Database
+
+These files are used in building an image from a SQL file. This was originally started in a separate internal repository but has been moved here because it is simpler to maintain and we don't need an additional dependency.

--- a/assets/dockerize-db-ddev/create_init_db.sh
+++ b/assets/dockerize-db-ddev/create_init_db.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+SOCKET=/var/tmp/mysql.sock
+OUTDIR=/mysqlbase
+
+mkdir -p ${OUTDIR}
+chown -R "$(id -u):$(id -g)" $OUTDIR
+
+chmod ugo+w /var/tmp
+mkdir -p /var/lib/mysql /mnt/ddev_config/mysql && rm -f /var/lib/mysql/* && chmod -R ugo+w /var/lib/mysql
+
+echo 'Initializing mysql'
+mysqld --version
+mysqld_version=$(mysqld --version | awk '{ gsub(/-log/, ""); gsub(/\.[0-9]+$/, "", $3);  print $3}')
+echo version=$mysqld_version
+# Oracle mysql 5.7+ deprecates mysql_install_db
+if [ "${mysqld_version}" = "5.7" ] || [  "${mysqld_version%%%.*}" = "8.0" ]; then
+    mysqld --initialize-insecure --datadir=/var/lib/mysql --server-id=0
+else
+    # mysql 5.5 requires running mysql_install_db in /usr/local/mysql
+    if command -v mysqld | grep usr.local; then
+        cd /usr/local/mysql
+    fi
+    mysql_install_db --force --datadir=/var/lib/mysql
+fi
+echo "Starting mysqld --skip-networking --socket=${SOCKET}"
+mysqld --user=root --socket=$SOCKET --innodb_log_file_size=48M --skip-networking --datadir=/var/lib/mysql --server-id=0 --skip-log-bin &
+pid="$!"
+
+# Wait for the server to respond to mysqladmin ping, or fail if it never does,
+# or if the process dies.
+for i in {90..0}; do
+	if mysqladmin ping -uroot --socket=$SOCKET 2>/dev/null; then
+		break
+	fi
+	# Test to make sure we got it started in the first place. kill -s 0 just tests to see if process exists.
+	if ! kill -s 0 $pid 2>/dev/null; then
+		echo "MariaDB initialization startup failed"
+		exit 3
+	fi
+	sleep 1
+done
+if [ "$i" -eq 0 ]; then
+	echo 'MariaDB initialization startup process timed out.'
+	exit 4
+fi
+
+
+mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -uroot  mysql
+
+mysql -uroot <<EOF
+	CREATE DATABASE IF NOT EXISTS $MYSQL_DATABASE;
+	CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD';
+	CREATE USER '$MYSQL_USER'@'localhost' IDENTIFIED BY '$MYSQL_PASSWORD';
+
+	GRANT ALL ON $MYSQL_DATABASE.* TO '$MYSQL_USER'@'%';
+	GRANT ALL ON $MYSQL_DATABASE.* TO '$MYSQL_USER'@'localhost';
+
+	CREATE USER 'root'@'%' IDENTIFIED BY '$MYSQL_ROOT_PASSWORD';
+	GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION;
+	FLUSH PRIVILEGES;
+	FLUSH TABLES;
+EOF
+
+mysqladmin -uroot password root
+
+if [  "${mysqld_version%%%.*}" = "8.0" ]; then
+    mysql -uroot -proot <<EOF
+        ALTER USER 'db'@'%' IDENTIFIED WITH mysql_native_password BY '$MYSQL_PASSWORD';
+        ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY '$MYSQL_ROOT_PASSWORD';
+        ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '$MYSQL_ROOT_PASSWORD';
+EOF
+fi
+
+set +u
+source /usr/local/bin/docker-entrypoint.sh
+docker_process_init_files /docker-entrypoint-initdb.d/*
+set -u
+
+
+rm -rf $OUTDIR/*
+
+backuptool=mariabackup
+if command -v xtrabackup; then backuptool="xtrabackup --datadir=/var/lib/mysql"; fi
+${backuptool} --backup --target-dir=$OUTDIR --user=root --password=root --socket=$SOCKET
+
+# Initialize with current mariadb_version
+my_mariadb_version=$(PATH=$PATH:/usr/sbin:/usr/local/bin:/usr/local/mysql/bin mysqld -V 2>/dev/null | awk '{sub( /\.[0-9]+(-.*)?$/, "", $3); print $3 }')
+echo $my_mariadb_version >$OUTDIR/db_mariadb_version.txt
+
+if ! kill -s TERM "$pid" || ! wait "$pid"; then
+	echo >&2 'Database initialization process failed.'
+	exit 5
+fi
+
+echo "The startup database files (in mariabackup/xtradb format) are now in $OUTDIR"

--- a/assets/dockerize-db-ddev/zzzz-truncate-caches.sql
+++ b/assets/dockerize-db-ddev/zzzz-truncate-caches.sql
@@ -1,0 +1,44 @@
+-- From https://stackoverflow.com/a/52370521/124844
+
+DROP PROCEDURE IF EXISTS truncate_tables;
+
+DELIMITER $$
+CREATE PROCEDURE truncate_tables()
+BEGIN
+  DECLARE tblName CHAR(64);
+  DECLARE done INT DEFAULT FALSE;
+  DECLARE dbTables CURSOR FOR
+    SELECT table_name
+    FROM information_schema.tables
+    WHERE table_schema = (SELECT DATABASE()) AND
+        (table_name LIKE 'cache%' OR
+        table_name LIKE 'search_%' OR
+        table_name LIKE 'old_%' OR
+        table_name IN ('flood', 'batch', 'queue', 'sessions', 'semaphore'));
+  DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+
+  OPEN dbTables;
+  SET FOREIGN_KEY_CHECKS = 0;
+
+  read_loop: LOOP
+    FETCH dbTables INTO tblName;
+    IF done THEN
+      LEAVE read_loop;
+    END IF;
+
+    PREPARE stmt FROM CONCAT('TRUNCATE ', tblName);
+    EXECUTE stmt;
+    DEALLOCATE PREPARE stmt;
+
+    PREPARE stmt FROM CONCAT('OPTIMIZE TABLE ', tblName);
+    EXECUTE stmt;
+    DEALLOCATE PREPARE stmt;
+  END LOOP read_loop;
+
+  CLOSE dbTables;
+  SET FOREIGN_KEY_CHECKS = 1;
+END
+$$
+
+CALL truncate_tables();
+DROP PROCEDURE IF EXISTS truncate_tables;

--- a/src/OptionsProvider.php
+++ b/src/OptionsProvider.php
@@ -37,12 +37,24 @@ class OptionsProvider
             'db-source' => '',
             'no-push' => false,
         ];
-        $this->packageConfig['docker-base'] += [
+
+        $baseImageDetailsDefault = [
+            'base-flavor' => 'bitnami',
             'image' => 'bitnami/mariadb:10.4',
             'user' => 'drupal8',
             'password' => 'drupal8',
             'database' => 'drupal8',
         ];
+        $baseFlavor = $this->packageConfig['docker-base']['base-flavor'] ?? 'default';
+        if ($baseFlavor == 'ddev') {
+            $baseImageDetailsDefault = [
+                'image' => 'drud/ddev-dbserver-mariadb-10.4:v1.17.0',
+                'user' => 'db',
+                'password' => 'db',
+                'database' => 'db',
+            ];
+        }
+        $this->packageConfig['docker-base'] += $baseImageDetailsDefault;
     }
 
     public function getDockerTag(): string

--- a/tests/OptionsProviderTest.php
+++ b/tests/OptionsProviderTest.php
@@ -63,6 +63,7 @@ class OptionsProviderTest extends TestCase
             'docker-image-name' => 'auto',
             'docker-tag' => 'auto',
             'docker-base' => [
+                'base-flavor' => 'bitnami',
                 'image' => 'bitnami/mariadb:10.4',
                 'user' => 'drupal8',
                 'password' => 'drupal8',
@@ -178,15 +179,38 @@ class OptionsProviderTest extends TestCase
                 'db-source' => 'lando',
             ],
             'expected' => [
+                    'docker-tag' => 'latest',
+                    'docker-base' => [
+                        'image' => 'mariadb:latest',
+                        'user' => 'drupal8',
+                        'password' => 'drupal8',
+                        'database' => 'drupal8',
+                    ],
+                    'db-source' => 'lando',
+                ] + $defaultExpected,
+        ];
+
+        // Partial configuration with DDEV base flavor.
+        $cases[] = [
+            'input' => $defaultInput,
+            'package' => [
                 'docker-tag' => 'latest',
                 'docker-base' => [
-                    'image' => 'mariadb:latest',
-                    'user' => 'drupal8',
-                    'password' => 'drupal8',
-                    'database' => 'drupal8',
+                    'base-flavor' => 'ddev',
                 ],
                 'db-source' => 'lando',
-            ] + $defaultExpected,
+            ],
+            'expected' => [
+                    'docker-tag' => 'latest',
+                    'docker-base' => [
+                        'base-flavor' => 'ddev',
+                        'image' => 'drud/ddev-dbserver-mariadb-10.4:v1.17.0',
+                        'user' => 'db',
+                        'password' => 'db',
+                        'database' => 'db',
+                    ],
+                    'db-source' => 'lando',
+                ] + $defaultExpected,
         ];
 
         return $cases;


### PR DESCRIPTION
This fixes #15 but with a few workarounds. The change here needs to repeat a few steps from the base image because we are recreating the `/mysqlbase` directory contents. This also increases the image size but there is no good way around this. More details in #15.

The `create_init_db.sh` script is copied from DDEV's [`create_base_db.sh`](https://github.com/drud/ddev/blob/master/containers/ddev-dbserver/files/create_base_db.sh) with only these changes inserted into the middle of the file (just before `mariabackup` is run:

```
set +u
source /usr/local/bin/docker-entrypoint.sh
docker_process_init_files /docker-entrypoint-initdb.d/*
set -u
```

It needs to call `set +u` to disable unset variable checks. MariaDB's `docker-entrypoint.sh` does not reliably check for this in [the `docker_process_sql` function](https://github.com/MariaDB/mariadb-docker/blob/8be7abacca5f19d487b137c7d8f9516d07116109/10.5/docker-entrypoint.sh#L227) resulting in an error because of `$1`.

```
/usr/local/bin/docker-entrypoint.sh: line 197: $1: unbound variable
```

Rather than fixing the error, it's simpler to just disable the check. This may not be a long-term fix but works now and hopefully a better solution exists which can be used upstream in DDEV.